### PR TITLE
fix(DT-3300): add sending_queue and retry_on_failure to otlphttp exporters

### DIFF
--- a/share_files/otel-collector-config-trace.yaml
+++ b/share_files/otel-collector-config-trace.yaml
@@ -8,7 +8,7 @@ receivers:
   prometheus/ecs:
     config:
       scrape_configs:
-      - job_name: opentelemetry-collector-trace
+      - job_name: opentelemetry-collector-proxy-trace
         scrape_interval: 10s
         static_configs:
           - targets:

--- a/share_files/otel-collector-config-trace.yaml
+++ b/share_files/otel-collector-config-trace.yaml
@@ -20,15 +20,15 @@ exporters:
   otlphttp/cent-monitor:
     endpoint: "https://cent-otel.ops.splashtop.com:443"
     sending_queue:
-      queue_size: ${env:otel_cent_queue_size:-200}
+      queue_size: ${env:otel_conf_cent_queue_size:-200}
     retry_on_failure:
-      max_elapsed_time: ${env:otel_cent_retry_max:-300}s
+      max_elapsed_time: ${env:otel_conf_cent_retry_max:-300}s
   otlphttp/tperd-monitor:
     endpoint: "https://cent-otel-devops.ops.tperd.splashtop.eu:443"
     sending_queue:
-      queue_size: ${env:otel_tperd_queue_size:-200}
+      queue_size: ${env:otel_conf_tperd_queue_size:-200}
     retry_on_failure:
-      max_elapsed_time: ${env:otel_tperd_retry_max:-300}s
+      max_elapsed_time: ${env:otel_conf_tperd_retry_max:-300}s
 
 processors:
   batch: {}

--- a/share_files/otel-collector-config-trace.yaml
+++ b/share_files/otel-collector-config-trace.yaml
@@ -19,8 +19,16 @@ exporters:
     verbosity: ${env:otel_conf_debug_verbosity}
   otlphttp/cent-monitor:
     endpoint: "https://cent-otel.ops.splashtop.com:443"
+    sending_queue:
+      queue_size: ${env:otel_cent_queue_size:-200}
+    retry_on_failure:
+      max_elapsed_time: ${env:otel_cent_retry_max:-300}s
   otlphttp/tperd-monitor:
     endpoint: "https://cent-otel-devops.ops.tperd.splashtop.eu:443"
+    sending_queue:
+      queue_size: ${env:otel_tperd_queue_size:-200}
+    retry_on_failure:
+      max_elapsed_time: ${env:otel_tperd_retry_max:-300}s
 
 processors:
   batch: {}

--- a/share_files/otel-collector-config.yaml
+++ b/share_files/otel-collector-config.yaml
@@ -31,8 +31,16 @@ exporters:
     routing_key: traceID
   otlphttp/cent-monitor:
     endpoint: "https://cent-otel.ops.splashtop.com:443"
+    sending_queue:
+      queue_size: ${env:otel_cent_queue_size:-200}
+    retry_on_failure:
+      max_elapsed_time: ${env:otel_cent_retry_max:-300}s
   otlphttp/tperd-monitor:
     endpoint: "https://cent-otel-devops.ops.tperd.splashtop.eu:443"
+    sending_queue:
+      queue_size: ${env:otel_tperd_queue_size:-200}
+    retry_on_failure:
+      max_elapsed_time: ${env:otel_tperd_retry_max:-300}s
 
 processors:
   batch: {}

--- a/share_files/otel-collector-config.yaml
+++ b/share_files/otel-collector-config.yaml
@@ -8,7 +8,7 @@ receivers:
   prometheus/ecs:
     config:
       scrape_configs:
-      - job_name: opentelemetry-collector
+      - job_name: opentelemetry-collector-proxy
         scrape_interval: 10s
         static_configs:
           - targets:

--- a/share_files/otel-collector-config.yaml
+++ b/share_files/otel-collector-config.yaml
@@ -32,15 +32,15 @@ exporters:
   otlphttp/cent-monitor:
     endpoint: "https://cent-otel.ops.splashtop.com:443"
     sending_queue:
-      queue_size: ${env:otel_cent_queue_size:-200}
+      queue_size: ${env:otel_conf_cent_queue_size:-200}
     retry_on_failure:
-      max_elapsed_time: ${env:otel_cent_retry_max:-300}s
+      max_elapsed_time: ${env:otel_conf_cent_retry_max:-300}s
   otlphttp/tperd-monitor:
     endpoint: "https://cent-otel-devops.ops.tperd.splashtop.eu:443"
     sending_queue:
-      queue_size: ${env:otel_tperd_queue_size:-200}
+      queue_size: ${env:otel_conf_tperd_queue_size:-200}
     retry_on_failure:
-      max_elapsed_time: ${env:otel_tperd_retry_max:-300}s
+      max_elapsed_time: ${env:otel_conf_tperd_retry_max:-300}s
 
 processors:
   batch: {}


### PR DESCRIPTION
## Summary
Three related changes on the shared GitHub Pages otel-collector configs that drive every ECS otel-collector instance (polkast / ocstack / be-prod-global / rd-qa-eu / rd-qa-global / tperd-dev).

**1. Add `sending_queue` and `retry_on_failure` caps to `otlphttp/cent-monitor` and `otlphttp/tperd-monitor`** (both `otel-collector-config.yaml` and `otel-collector-config-trace.yaml`).
   - OTel defaults (`queue_size=1000`, no `max_elapsed_time`) let the queue grow to ~3 GB (1000 batches × ~3 MB) while upstream is 503'ing → memory_limiter is an input-side rate limiter and cannot drain a full queue → OOM.
   - Fallback values **`queue_size: 200`** and **`max_elapsed_time: 300s`** match the EKS helm chart pattern (`be-app-prod-*` values).

**2. Wire the caps through env vars so each ECS env can tune per task memory budget via tfvars**:
   - `otel_conf_cent_queue_size`, `otel_conf_cent_retry_max`, `otel_conf_tperd_queue_size`, `otel_conf_tperd_retry_max`
   - Names follow the existing `otel_conf_*` family (`otel_conf_debug_verbosity`, `otel_conf_splashtop_env`, etc.) so the Terraform module can register them consistently.
   - Without env vars set, behavior = literal 200 / 300s (same as A-plan).

**3. Rename the prometheus self-scrape `job_name` to clarify proxy role**:
   - `opentelemetry-collector` → `opentelemetry-collector-proxy`
   - `opentelemetry-collector-trace` → `opentelemetry-collector-proxy-trace`
   - These ECS collectors are OTLP forwarders to cent-monitor/tperd-monitor — distinct from EKS otel-collector pods that also expose self-metrics under the generic `opentelemetry-collector` label. The new names let queries / future dashboards / alert rules target the proxy fleet specifically.
   - Verified via Mimir-PROD label values + grep over `observability-service-app/` that **no dashboard or alert references the old job label**.

## Jira
[DT-3300](https://splashtop.atlassian.net/browse/DT-3300) — root cause of 2026-06-23 23:50 UTC EU-Prod ECS otel-collector OOM. Logs show:
- cent-otel (USW2) entered `memory_limiter` soft-limit (cur_mem_mib=3352) for ~50 s and returned HTTP 503 to upstreams ("data refused due to high memory usage")
- polkast ECS collector retry_sender kept retrying + receivers kept ingesting OTLP → `memory_limiter` hit hard-limit warning at `cur_mem_mib=3717`
- 0.2 s later the task was OOM-killed at 23:55:34.896 UTC

`memory_limiter` is an input-side rate limiter; it cannot drain an already-full sending queue. The fix bounds the queue depth (memory ceiling) and retry duration (drop stale items when upstream is stuck), with env-var override available per env, and renames the job label to make the proxy-vs-deployment distinction queryable.

## Test Plan
- [ ] GitHub Pages serves updated YAML within ~5 min after merge:
  ```
  curl -s https://splashtopinc.github.io/stp-o11y/share_files/otel-collector-config.yaml | grep -A2 sending_queue
  curl -s https://splashtopinc.github.io/stp-o11y/share_files/otel-collector-config.yaml | grep job_name
  ```
- [ ] Force-new-deployment on `tperd-dev` first (lowest blast radius):
  ```
  aws ecs update-service --cluster aws-tperd-o11y-ecs-cluster-apne1 \
    --service otel-collector --force-new-deployment \
    --profile aws-sso-tperd --region ap-northeast-1
  ```
- [ ] In Mimir-DEV / -PROD, verify the new job labels appear:
  - `otelcol_exporter_queue_capacity{job="opentelemetry-collector-proxy"}` → 200
  - `otelcol_exporter_queue_capacity{job="opentelemetry-collector-proxy-trace"}` → 200
  - Old `job="opentelemetry-collector"` series should age out after retention
- [ ] Roll across remaining ECS envs (rd-qa-eu, rd-qa-global, be-prod-global, ocstack OC-Prod, polkast EU-Prod)
- [ ] **Follow-up IaC PR** in `stp-devops-k8s-observability` will register the 4 env vars in the `ecs_otel_collector` Terraform module and set per-env values via tfvars (prod cent=500/600s, dev/qa cent=100/120s)

## Behavior Matrix
| Stage | queue_size on cent | max_elapsed_time on cent | Effect |
|---|---|---|---|
| Before this PR | unbounded (OTel default 1000) | unbounded | OOM-prone — this is what caused DT-3300 |
| After this PR, no IaC change | 200 (YAML fallback) | 300s (YAML fallback) | Bleed stopped; matches EKS helm pattern |
| After IaC PR sets prod=500/600s | 500 | 600s | Prod gets more buffer for longer upstream outages |

## Screenshots
N/A (config-only change)

[DT-3300]: https://splashtop.atlassian.net/browse/DT-3300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ