### PR TITLE
DT-3351 make service.instance.id unique per container in adot v2-0 config

### DIFF
--- a/share_files/adot-collector-config-v2-0.yaml
+++ b/share_files/adot-collector-config-v2-0.yaml
@@ -51,7 +51,7 @@ processors:
         value: ${env:ecs_service_name:-default-service}
         action: "insert"
   # Derive identity from the ECS metadata that awsecscontainermetrics already
-  # attaches, so task metrics split per service (and per task) instead of
+  # attaches, so metrics split per service (and per container/task) instead of
   # collapsing into one per-cluster series. insert keeps any value the source
   # already carries. Only wired into the ECS container metrics pipeline — that
   # is the only pipeline whose data has aws.ecs.* attributes.
@@ -59,6 +59,12 @@ processors:
     attributes:
       - key: "service.name"
         from_attribute: "aws.ecs.service.name"
+        action: "insert"
+      # Container-level metrics carry container.id (unique per container) — use
+      # it first. Task-level metrics lack it, so the next insert falls back to
+      # task.arn. insert never overwrites, so each level keeps its own value.
+      - key: "service.instance.id"
+        from_attribute: "container.id"
         action: "insert"
       - key: "service.instance.id"
         from_attribute: "aws.ecs.task.arn"


### PR DESCRIPTION
## Summary
- Fix ECS metric instance identity in the v2 adot config: container-level metrics of the same task share a task ARN, so keying `service.instance.id` on `aws.ecs.task.arn` alone collided across a task's containers. Now `service.instance.id` comes from `container.id` (unique per container) with a fallback to `aws.ecs.task.arn` for task-level metrics that lack it.

## Changes
- `share_files/adot-collector-config-v2-0.yaml`: in `resource/set_service_name`, insert `service.instance.id` from `container.id` first, then from `aws.ecs.task.arn`. `insert` never overwrites, so container-level metrics keep `container.id` and task-level metrics fall back to `task.arn`. Implemented with the `resource` processor only (ADOT distro has no OTTL `transform` processor).

## Jira
https://splashtop.atlassian.net/browse/DT-3351