### PR TITLE
DT-3351 drop the debug exporter from adot-collector-config-v2-0

### DIFF
--- a/share_files/adot-collector-config-v2-0.yaml
+++ b/share_files/adot-collector-config-v2-0.yaml
@@ -26,8 +26,6 @@ receivers:
               - ${env:HOSTNAME}:8888
 
 exporters:
-  debug:
-    verbosity: ${env:otel_conf_debug_verbosity:-basic}
   otlphttp/ecs-otel:
     endpoint: ${env:otlp_exporter_endpoint}
 
@@ -89,20 +87,20 @@ service:
     metrics/awsecscontainer:
       receivers: [awsecscontainermetrics, prometheus/ecs]
       processors: [memory_limiter, resource, resource/set_service_name, batch]
-      exporters: [otlphttp/ecs-otel, debug]
+      exporters: [otlphttp/ecs-otel]
     metrics:
       receivers: [otlp/ecs-adot]
       processors: [memory_limiter, resource, batch]
-      exporters: [otlphttp/ecs-otel, debug]
+      exporters: [otlphttp/ecs-otel]
     traces:
       receivers: [otlp/ecs-adot]
       processors: [memory_limiter, resource, batch]
-      exporters: [otlphttp/ecs-otel, debug]
+      exporters: [otlphttp/ecs-otel]
     logs:
       receivers: [otlp/ecs-adot]
       processors: [memory_limiter, resource, batch]
-      exporters: [otlphttp/ecs-otel, debug]
+      exporters: [otlphttp/ecs-otel]
     logs/filelog:
       receivers: [filelog]
       processors: [memory_limiter, resource, resource/log, batch]
-      exporters: [otlphttp/ecs-otel, debug]
+      exporters: [otlphttp/ecs-otel]


### PR DESCRIPTION
## Summary
- Remove the `debug` exporter from `adot-collector-config-v2-0.yaml` and from every pipeline. `debug` is a troubleshooting tool, not a steady-state exporter — even at `basic` verbosity it writes a summary line per batch per pipeline into CloudWatch for no operational value.

## Changes
- `share_files/adot-collector-config-v2-0.yaml`: delete the `debug` exporter definition; change all five pipelines' exporters from `[otlphttp/ecs-otel, debug]` to `[otlphttp/ecs-otel]`.

## Notes
- Collector health/throughput stays observable via self-telemetry already in this config: the `prometheus/ecs` self-scrape of `:8888` + `service.telemetry.metrics` (`otelcol_exporter_sent_*` / `otelcol_exporter_send_failed_*` / queue sizes).
- Consumers pick this up on their next task restart. The now-unused `otel_conf_debug_verbosity` env on task defs is harmless and can be cleaned up separately.

## Jira
https://splashtop.atlassian.net/browse/DT-3351