### PR TITLE
fix(DT-3358): drop PROD-OC from tperd-monitor dual-write

### DIFF
--- a/share_files/otel-collector-config-trace.yaml
+++ b/share_files/otel-collector-config-trace.yaml
@@ -78,17 +78,19 @@ processors:
       ]
 
 connectors:
-  # routing rules: 
+  # routing rules:
   # 1. DEV -> tperd-monitor & cent-monitor (for load testing)
-  # 2. PROD-OC & QA-EU -> both tperd-monitor & cent-monitor
-  # 3. OTHERS -> cent-monitor
+  # 2. QA-EU -> both tperd-monitor & cent-monitor
+  # 3. OTHERS (incl. PROD-OC) -> cent-monitor
+  # DT-3358: PROD-OC removed from tperd dual-write; TPE test stack could not
+  # keep up with real PROD volume, causing chronic 100% queue saturation.
   routing/traces:
     error_mode: ignore
     match_once: true
     table:
       - context: span
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "PROD") and IsMatch(resource.attributes["splashtop.stack"], "OC")
-        pipelines: [traces/multi-exporters]
+        pipelines: [traces/cent-monitor]
       - context: span
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "QA") and IsMatch(resource.attributes["splashtop.stack"], "EU")
         pipelines: [traces/multi-exporters]
@@ -104,7 +106,7 @@ connectors:
     table:
       - context: metric
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "PROD") and IsMatch(resource.attributes["splashtop.stack"], "OC")
-        pipelines: [metrics/multi-exporters]
+        pipelines: [metrics/cent-monitor]
       - context: metric
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "QA") and IsMatch(resource.attributes["splashtop.stack"], "EU")
         pipelines: [metrics/multi-exporters]

--- a/share_files/otel-collector-config.yaml
+++ b/share_files/otel-collector-config.yaml
@@ -67,17 +67,19 @@ processors:
         action: "insert"
 
 connectors:
-  # routing rules: 
+  # routing rules:
   # 1. DEV -> tperd-monitor & cent-monitor (for load testing)
-  # 2. PROD-OC & QA-EU -> both tperd-monitor & cent-monitor
-  # 3. OTHERS -> cent-monitor
+  # 2. QA-EU -> both tperd-monitor & cent-monitor
+  # 3. OTHERS (incl. PROD-OC) -> cent-monitor
+  # DT-3358: PROD-OC removed from tperd dual-write; TPE test stack could not
+  # keep up with real PROD volume, causing chronic 100% queue saturation.
   routing/traces:
     error_mode: ignore
     match_once: true
     table:
       - context: span
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "PROD") and IsMatch(resource.attributes["splashtop.stack"], "OC")
-        pipelines: [traces/multi-exporters]
+        pipelines: [traces/cent-monitor]
       - context: span
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "QA") and IsMatch(resource.attributes["splashtop.stack"], "EU")
         pipelines: [traces/multi-exporters]
@@ -93,7 +95,7 @@ connectors:
     table:
       - context: metric
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "PROD") and IsMatch(resource.attributes["splashtop.stack"], "OC")
-        pipelines: [metrics/multi-exporters]
+        pipelines: [metrics/cent-monitor]
       - context: metric
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "QA") and IsMatch(resource.attributes["splashtop.stack"], "EU")
         pipelines: [metrics/multi-exporters]
@@ -109,7 +111,7 @@ connectors:
     table:
       - context: log
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "PROD") and IsMatch(resource.attributes["splashtop.stack"], "OC")
-        pipelines: [logs/multi-exporters]
+        pipelines: [logs/cent-monitor]
       - context: log
         statement: route() where IsMatch(resource.attributes["splashtop.env"], "QA") and IsMatch(resource.attributes["splashtop.stack"], "EU")
         pipelines: [logs/multi-exporters]


### PR DESCRIPTION
## Summary
- OTel collector 的 `otlphttp/tperd-monitor` exporter 佇列在 PROD-OC (`o11y-ecs-cluster-apse2`) 長期 ~100% 滿載，每小時約 4700 萬 metric points 被丟棄。
- 根因：routing connector 讓 PROD-OC 用真實 prod 流量 dual-write 到 TPE 測試 stack (`cent-otel-devops.ops.tperd.splashtop.eu`)，該測試 stack 吞吐撐不住實際量 → 長期 backpressure（`send_failed`=0，端點可達但吞吐不足）。
- 主要 production 路徑 `cent-monitor` → 中央 Mimir 完全健康（queue=0，零丟失）；被丟的只有多餘的測試 stack 副本。
- 本 PR 把 PROD-OC 的 metrics / logs / traces 路由從 `multi-exporters` 改為 `cent-monitor`（只送中央）。**QA-EU 與 DEV 的 tperd dual-write 維持不變**（load test 保留）。
- 兩個 config 檔皆改：`otel-collector-config.yaml`（metrics/logs/traces）、`otel-collector-config-trace.yaml`（traces/metrics）。

## Jira
[DT-3358](https://splashtop.atlassian.net/browse/DT-3358)

## Test Plan
- [x] `yq` 驗證兩個 YAML 檔語法正確
- [x] 確認 PROD-OC 5 條路由規則全部指向 `cent-monitor`；QA-EU / DEV 仍指向 `multi-exporters`
- [ ] Merge 後 force `o11y-ecs-cluster-apse2` (OC-PROD) ECS redeploy 讓 collector 重抓 config（config 僅在 container 啟動時載入）
- [ ] 驗證 apse2 的 tperd-monitor queue 歸零、`enqueue_failed` 停止累積、`cent-monitor` 維持健康
- [ ] 確認 QA-EU 行為不變（不需重啟）

## Screenshots (if applicable)
N/A（後端 config 變更）

[DT-3358]: https://splashtop.atlassian.net/browse/DT-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ