### PR TITLE
DT-3410 give custom scrape-job metrics per-task identity so all ECS tasks report

### DIFF
--- a/share_files/adot-collector-config-custom-metrics.yaml
+++ b/share_files/adot-collector-config-custom-metrics.yaml
@@ -7,9 +7,40 @@ receivers:
         static_configs:
           - targets: ["${env:scrape_job_target:-127.0.0.1:8080}"]
 
+processors:
+  # The scrape target above is loopback, so it is byte-identical in every task of
+  # a service. The prometheus receiver derives service.instance.id from that
+  # address, which gave every task the same series identity: one task's samples
+  # won and the rest were dropped as duplicates, and a task replacement looked
+  # like a counter reset on the surviving series. Detect the task from the ECS
+  # Task Metadata Endpoint so identity can come from ECS instead of the address.
+  # TMDE is not a new dependency here — awsecscontainermetrics in the base config
+  # already queries it.
+  resourcedetection/ecs:
+    detectors: [ecs]
+    timeout: 5s
+    override: false
+
+  # upsert, not insert: the prometheus receiver has already filled
+  # service.instance.id with the loopback address, so insert would be a no-op
+  # (this is also why the base config's resource/set_service_name cannot be
+  # reused here — that one inserts, and its aws.ecs.* sources are absent from
+  # scraped data anyway).
+  #
+  # aws.ecs.task.arn rather than aws.ecs.task.id: task.arn is a documented
+  # attribute of the ecs detector, while task.id is not present in every
+  # collector version. Task ARN is also what the task-level ECS metrics already
+  # use as their instance, so application metrics stay joinable against
+  # ecs_task_* for the same task.
+  resource/custom_job_instance:
+    attributes:
+      - key: "service.instance.id"
+        from_attribute: "aws.ecs.task.arn"
+        action: "upsert"
+
 service:
   pipelines:
     metrics/custom-job:
       receivers: [prometheus/custom-job]
-      processors: [memory_limiter, resource, batch]
+      processors: [memory_limiter, resource, resourcedetection/ecs, resource/custom_job_instance, batch]
       exporters: [otlphttp/ecs-otel]


### PR DESCRIPTION
## Summary
- The custom-job scrape target is loopback, so it is identical in every task of a service and the prometheus receiver gave every task the same `service.instance.id`. Only one task's samples were stored; the rest were rejected as duplicates.
- Identity now comes from the ECS task ARN, so every task reports independently.

## Why this matters most for ais-vibe-crawler
It runs 6 tasks. Measured in PROD before this change:

| metric family | series | correct? |
| --- | --- | --- |
| `container_*` | 18 (3 containers x 6 tasks) | yes |
| `ecs_task_*` | 6 | yes |
| `process_cpu_seconds_total`, `up`, `scrape_*` | 1 each | no |

`process_start_time_seconds` was a single series held constant at one task's start time, while the other five tasks had started at five different times and appeared nowhere. Five of six tasks' application metrics were being discarded, so the crawler dashboards understated traffic by roughly 6x, and a single `up` series could not reveal that five of six tasks were unhealthy.

`emm-api-proxy-service` runs 2 tasks and had the same problem at 1/2. `asset-inventory-worker-otel` runs 1 task, so it was only affected during rollouts — it showed a `rate()` spike of 53.3K jobs/s against a 7 jobs/s steady state, because a task replacement looked like a counter reset and `rate()` added the pre-reset value back as a correction.

## Changes
- `share_files/adot-collector-config-custom-metrics.yaml`: add `resourcedetection/ecs` and `resource/custom_job_instance`, and wire both into the `metrics/custom-job` pipeline. `service.instance.id` is upserted from `aws.ecs.task.arn`.

`upsert` rather than `insert`, because the prometheus receiver has already filled `service.instance.id` with the loopback address. This is also why the base config's `resource/set_service_name` cannot be reused here: it inserts, and its `aws.ecs.*` sources are absent from scraped data.

`aws.ecs.task.arn` rather than `aws.ecs.task.id`, because task.arn is a documented attribute of the ecs detector while task.id is not present in every collector version. Task ARN is also what the task-level ECS metrics use as their `instance`, so application metrics become joinable against `ecs_task_*` for the same task. `${env:HOSTNAME}` would have been unique per task as well, but would have broken that join.

That join works for `ais-vibe-crawler` and `asset-inventory-worker-otel`, whose `scrape_job_name` already equals their ECS service name and whose tasks run the v2-0 base config, so both label sets line up on `job` and `instance`. It does **not** work for `emm-api-proxy-service`, for two reasons unrelated to this change: its tasks load `adot-collector-config.yaml` rather than `adot-collector-config-v2-0.yaml`, so they never get `resource/set_service_name` and their `ecs_task_*` series carry no `job` or `instance` at all; and its `scrape_job_name` is `emm-api-proxy-service` while its ECS service is named `emm-proxy`. This change still fixes its per-task collapse (2 tasks stop sharing one series), it just does not gain the join.

TMDE is not a new dependency: `awsecscontainermetrics` in the base config already queries it.

## Effect on consumers
- `service.name` is untouched, so the `job` label does not change and queries keyed on `job` keep working. Only `instance` changes, from `127.0.0.1:<port>` to the task ARN.
- Aggregate values step up as the previously discarded tasks start reporting: roughly 6x for `ais-vibe-crawler`, 2x for `emm-api-proxy-service`. The data becomes correct, but the graphs will look like a traffic surge. This is worth announcing before it lands.
- Series count per service multiplies by its task count.

## Before merging
- **Alert audit.** The Grafana API rule listing returns titles without query expressions, so this could not be checked programmatically. `[PROD]` and `[QA] Error exceptions - emm-api-proxy-service` are known to need review. Any alert with an absolute threshold on request counts will fire on the step change.
- **Rollout staging.** This file is served from `gh-pages`, so merging takes effect for all three services the next time their collectors load config; there is no per-environment gate. If QA-first validation is required, that needs a versioned filename (as with `adot-collector-config-v2-0.yaml`) plus a taskdef change. Please advise which you prefer — the change itself is env-agnostic.

## Verification
Series count per service should equal its running task count; `ais-vibe-crawler` goes from 1 to 6. Config merge was checked against `adot-collector-config-v2-0.yaml`: no processor name collisions, every processor referenced by the pipeline is defined, and the base config does not define `metrics/custom-job`.

## Follow-up (not in this PR)
The `prometheus/ecs` self-scrape job in `adot-collector-config-v2-0.yaml` still identifies itself by `${env:HOSTNAME}`, so `job=aws-otel-collector` metrics remain unjoinable with the ECS metrics. Aligning it belongs with the v2-0 config.

`emm-proxy` is still on `adot-collector-config.yaml`. Moving it to v2-0 would give its ECS metrics per-service and per-task identity, and would make the join above available to it as well.

## Jira
https://splashtop.atlassian.net/browse/DT-3410
